### PR TITLE
Fixing Error: Ambiguous use of 'popLast()'

### DIFF
--- a/Sources/PostgreSQL/Data/PostgreSQLData+Point.swift
+++ b/Sources/PostgreSQL/Data/PostgreSQLData+Point.swift
@@ -49,8 +49,10 @@ extension PostgreSQLPoint: PostgreSQLDataCustomConvertible {
                 let parts = string.split(separator: ",")
                 var x = parts[0]
                 var y = parts[1]
-                assert(x.popFirst()! == "(")
-                assert(y.popLast()! == ")")
+                assert(x.first! == "(")
+                assert(y.last! == ")")
+                x.removeFirst()
+                y.removeLast()
                 return .init(x: Double(x)!, y: Double(y)!)
             case .binary:
                 let x = value[0..<8]


### PR DESCRIPTION
### PostgreSQL would not compile due to: `Ambiguous use of 'popLast()'`
#### Here's a working (workaround?)

`x.popFirst()!`
returns the first element of the collection if not empty.
Otherwise nil.
Plus removes first element from x.

`x.first!`
returns the first element of the collection if not empty.
Otherwise nil.
Does not removes first element from x.

That's why I added: `x.removeFirst()` afterwards.

### Toolchain
**Swift Development Snapshot 2018-02-13 (a)**