### PR TITLE
Fix a memory leak in `PostgreSQLConnection`

### DIFF
--- a/Sources/PostgreSQL/Connection/PostgreSQLConnection.swift
+++ b/Sources/PostgreSQL/Connection/PostgreSQLConnection.swift
@@ -18,7 +18,7 @@ public final class PostgreSQLConnection {
     public var logger: PostgreSQLLogger?
 
     /// Caches oid -> table name data.
-    internal var tableNameCache: PostgreSQLTableNameCache?
+    internal weak var tableNameCache: PostgreSQLTableNameCache?
 
     /// Creates a new Redis client on the provided data source and sink.
     init(queue: QueueHandler<PostgreSQLMessage, PostgreSQLMessage>, channel: Channel) {


### PR DESCRIPTION
`PostgreSQLTableNameCache` holds a `PostgreSQLConnection` future. Once that future is fulfilled, it strongly holds a reference to `PostgreSQLConnection`. That connection in turn holds the table name cache, so we have a reference cycle. This causes the table name cache and its connection to never get released. This is relevant when testing, if the tests are set up such that each test creates a new `Database`.