### PR TITLE
Prevent `PostgreSQLDatabase` from leaking an event loop group.

### DIFF
--- a/Sources/PostgreSQL/Connection/PostgreSQLConnection+TCP.swift
+++ b/Sources/PostgreSQL/Connection/PostgreSQLConnection+TCP.swift
@@ -2,13 +2,13 @@ import Async
 import NIO
 
 extension PostgreSQLConnection {
-    /// Connects to a Redis server using a TCP socket.
+    /// Connects to a PostgreSQL server using a TCP socket.
     public static func connect(
         hostname: String = "localhost",
         port: Int = 5432,
         on worker: Worker,
         onError: @escaping (Error) -> ()
-    ) throws -> Future<PostgreSQLConnection> {
+    ) -> Future<PostgreSQLConnection> {
         let handler = QueueHandler<PostgreSQLMessage, PostgreSQLMessage>(on: worker, onError: onError)
         let bootstrap = ClientBootstrap(group: worker.eventLoop)
             // Enable SO_REUSEADDR.

--- a/Sources/PostgreSQL/Connection/PostgreSQLConnection.swift
+++ b/Sources/PostgreSQL/Connection/PostgreSQLConnection.swift
@@ -8,7 +8,7 @@ public final class PostgreSQLConnection {
         return channel.eventLoop
     }
 
-    /// Handles enqueued redis commands and responses.
+    /// Handles enqueued PostgreSQL commands and responses.
     private let queue: QueueHandler<PostgreSQLMessage, PostgreSQLMessage>
 
     /// The channel
@@ -20,7 +20,7 @@ public final class PostgreSQLConnection {
     /// Caches oid -> table name data.
     internal weak var tableNameCache: PostgreSQLTableNameCache?
 
-    /// Creates a new Redis client on the provided data source and sink.
+    /// Creates a new PostgreSQL client on the provided data source and sink.
     init(queue: QueueHandler<PostgreSQLMessage, PostgreSQLMessage>, channel: Channel) {
         self.queue = queue
         self.channel = channel

--- a/Sources/PostgreSQL/Database/PostgreSQLDatabase.swift
+++ b/Sources/PostgreSQL/Database/PostgreSQLDatabase.swift
@@ -9,20 +9,31 @@ public final class PostgreSQLDatabase: Database {
     public var logger: PostgreSQLLogger?
 
     /// Caches oid -> table name data.
-    internal var tableNameCache: PostgreSQLTableNameCache?
+    internal private(set) var tableNameCache: PostgreSQLTableNameCache?
+
+    /// Keeps a reference to the table name cache's event loop, so we can shut it down on deinit.
+    private let eventLoopGroup: MultiThreadedEventLoopGroup
 
     /// Creates a new `PostgreSQLDatabase`.
     public init(config: PostgreSQLDatabaseConfig) {
         self.config = config
-        let group = MultiThreadedEventLoopGroup(numThreads: 1)
-        self.tableNameCache = PostgreSQLTableNameCache(connection: makeConnection(on: group))
+        self.eventLoopGroup = MultiThreadedEventLoopGroup(numThreads: 1)
+        self.tableNameCache = PostgreSQLTableNameCache(connection: makeConnection(on: eventLoopGroup))
+    }
+
+    deinit {
+        eventLoopGroup.shutdownGracefully() {
+            if let error = $0 {
+                print("[PostgreSQL] shutting down event loop: \(error)")
+            }
+        }
     }
 
     /// See `Database.makeConnection()`
     public func makeConnection(on worker: Worker) -> Future<PostgreSQLConnection> {
         let config = self.config
         return Future.flatMap(on: worker) {
-            return try PostgreSQLConnection.connect(hostname: config.hostname, port: config.port, on: worker) { error in
+            return PostgreSQLConnection.connect(hostname: config.hostname, port: config.port, on: worker) { error in
                 print("[PostgreSQL] \(error)")
             }.flatMap(to: PostgreSQLConnection.self) { client in
                 client.logger = self.logger


### PR DESCRIPTION
Instead, we keep the event loop group around and shut it down on `deinit`.