### PR TITLE
Close a `PostgreSQLConnection`'s channel on deinit.

### DIFF
--- a/Sources/PostgreSQL/Connection/PostgreSQLConnection.swift
+++ b/Sources/PostgreSQL/Connection/PostgreSQLConnection.swift
@@ -25,6 +25,10 @@ public final class PostgreSQLConnection {
         self.queue = queue
         self.channel = channel
     }
+    
+    deinit {
+        close()
+    }
 
     /// Sends `PostgreSQLMessage` to the server.
     func send(_ messages: [PostgreSQLMessage], onResponse: @escaping (PostgreSQLMessage) throws -> ()) -> Future<Void> {


### PR DESCRIPTION
Otherwise, the connection is never claused, and PostgreSQL might complain about too many open connections.