### PR TITLE
Fix parsing of database name from url

### DIFF
--- a/Sources/PostgreSQL/Database/PostgreSQLDatabaseConfig.swift
+++ b/Sources/PostgreSQL/Database/PostgreSQLDatabaseConfig.swift
@@ -3,7 +3,7 @@ import Foundation
 public struct PostgreSQLDatabaseConfig {
     /// Creates a `PostgreSQLDatabaseConfig` with default settings.
     public static func `default`() -> PostgreSQLDatabaseConfig {
-        return .init(hostname: "localhost", port: 5432, username: "postgres")
+        return .init(hostname: "localhost", port: nil, username: "postgres")
     }
 
     /// Destination hostname.
@@ -23,9 +23,9 @@ public struct PostgreSQLDatabaseConfig {
     public let password: String?
     
     /// Creates a new `PostgreSQLDatabaseConfig`.
-    public init(hostname: String, port: Int = 5432, username: String, database: String? = nil, password: String? = nil) {
+    public init(hostname: String, port: Int?, username: String, database: String? = nil, password: String? = nil) {
         self.hostname = hostname
-        self.port = port
+        self.port = port ?? 5432
         self.username = username
         self.database = database
         self.password = password
@@ -34,22 +34,18 @@ public struct PostgreSQLDatabaseConfig {
     /// Creates a `PostgreSQLDatabaseConfig` frome a connection string.
     public init(url: String) throws {
         guard let urL = URL(string: url),
-            let hostname = urL.host,
-            let port = urL.port,
             let username = urL.user,
-            let database = URL(string: url)?.path,
-            database.count > 0
+			let hostname = urL.host,
+            let path = URL(string: url)?.path,
+			"postgres" == urL.scheme
              else {
                 throw PostgreSQLError(identifier: "Bad Connection String",
-                                 reason: "Host could not be parsed",
+                                 reason: "Config could not be parsed",
                                  possibleCauses: ["Foundation URL is unable to parse the provided connection string"],
                                  suggestedFixes: ["Check the connection string being passed"],
                                  source: .capture())
         }
-        self.hostname = hostname
-        self.port = port
-        self.username = username
-        self.database = database
-        self.password = urL.password
+		let database = String(path.dropFirst())
+		self.init(hostname: hostname, port: urL.port, username: username, database: database, password: urL.password)
     }
 }

--- a/Tests/PostgreSQLTests/PostgreSQLConnectionTests.swift
+++ b/Tests/PostgreSQLTests/PostgreSQLConnectionTests.swift
@@ -342,6 +342,17 @@ class PostgreSQLConnectionTests: XCTestCase {
         _ = try categories.wait()
     }
 
+	func testPostgreSQLDatabaseConfig() throws {
+		let config = try PostgreSQLDatabaseConfig(url: "postgres://user@host:1234/db")
+		XCTAssertEqual(config.hostname, "host")
+		XCTAssertEqual(config.port, 1234)
+		XCTAssertEqual(config.username, "user")
+		XCTAssertEqual(config.database, "db")
+
+		XCTAssertThrowsError(try PostgreSQLDatabaseConfig(url: "https://host/path"))
+		XCTAssertThrowsError(try PostgreSQLDatabaseConfig(url: "postgres://nouser"))
+	}
+
     static var allTests = [
         ("testVersion", testVersion),
         ("testSelectTypes", testSelectTypes),

--- a/Tests/PostgreSQLTests/PostgreSQLConnectionTests.swift
+++ b/Tests/PostgreSQLTests/PostgreSQLConnectionTests.swift
@@ -342,7 +342,7 @@ class PostgreSQLConnectionTests: XCTestCase {
         _ = try categories.wait()
     }
 
-	func testPostgreSQLDatabaseConfig() throws {
+	func testGH33() throws {
 		let config = try PostgreSQLDatabaseConfig(url: "postgres://user@host:1234/db")
 		XCTAssertEqual(config.hostname, "host")
 		XCTAssertEqual(config.port, 1234)
@@ -362,6 +362,7 @@ class PostgreSQLConnectionTests: XCTestCase {
         ("testStruct", testStruct),
         ("testNull", testNull),
         ("testGH24", testGH24),
+        ("testGH33", testGH33),
     ]
 }
 


### PR DESCRIPTION
Fixes #33 and adds some additional validation to url scheme as per https://www.postgresql.org/docs/current/static/libpq-connect.html#LIBPQ-CONNSTRING