### PR TITLE
Add support for SSL connections

### DIFF
--- a/Sources/PostgreSQL/Database/PostgreSQLDatabase.swift
+++ b/Sources/PostgreSQL/Database/PostgreSQLDatabase.swift
@@ -17,15 +17,23 @@ public final class PostgreSQLDatabase: Database {
     public func makeConnection(on worker: Worker) -> Future<PostgreSQLConnection> {
         let config = self.config
         return Future.flatMap(on: worker) {
-            return try PostgreSQLConnection.connect(hostname: config.hostname, port: config.port, on: worker) { error in
+            var connection = try PostgreSQLConnection.connect(hostname: config.hostname, port: config.port, on: worker) { error in
                 print("[PostgreSQL] \(error)")
-            }.flatMap(to: PostgreSQLConnection.self) { client in
+            }
+
+            if config.shouldPreferSSL ?? false {
+                connection = connection.flatMap(to: PostgreSQLConnection.self) { client in
+                    return client.establishSSLConnection().transform(to: client)
+                }
+            }
+
+            return connection.flatMap(to: PostgreSQLConnection.self) { client in
                 client.logger = self.logger
                 return client.authenticate(
                     username: config.username,
                     database: config.database,
                     password: config.password
-                ).transform(to: client)
+                    ).transform(to: client)
             }
         }
     }

--- a/Sources/PostgreSQL/Database/PostgreSQLDatabase.swift
+++ b/Sources/PostgreSQL/Database/PostgreSQLDatabase.swift
@@ -21,7 +21,7 @@ public final class PostgreSQLDatabase: Database {
                 print("[PostgreSQL] \(error)")
             }
 
-            if config.shouldPreferSSL ?? false {
+            if config.shouldPreferSSL {
                 connection = connection.flatMap(to: PostgreSQLConnection.self) { client in
                     return client.establishSSLConnection().transform(to: client)
                 }

--- a/Sources/PostgreSQL/Database/PostgreSQLDatabaseConfig.swift
+++ b/Sources/PostgreSQL/Database/PostgreSQLDatabaseConfig.swift
@@ -23,10 +23,10 @@ public struct PostgreSQLDatabaseConfig {
     public let password: String?
 
     /// Optional ssl connection
-    public let shouldPreferSSL: Bool?
+    public let shouldPreferSSL: Bool
     
     /// Creates a new `PostgreSQLDatabaseConfig`.
-    public init(hostname: String, port: Int = 5432, username: String, database: String? = nil, password: String? = nil, shouldPreferSSL: Bool? = false) {
+    public init(hostname: String, port: Int = 5432, username: String, database: String? = nil, password: String? = nil, shouldPreferSSL: Bool = false) {
         self.hostname = hostname
         self.port = port
         self.username = username
@@ -36,7 +36,7 @@ public struct PostgreSQLDatabaseConfig {
     }
 
     /// Creates a `PostgreSQLDatabaseConfig` frome a connection string.
-    public init(url: String, shouldPreferSSL: Bool? = false) throws {
+    public init(url: String, shouldPreferSSL: Bool = false) throws {
         guard let urL = URL(string: url),
             let hostname = urL.host,
             let port = urL.port,

--- a/Sources/PostgreSQL/Database/PostgreSQLDatabaseConfig.swift
+++ b/Sources/PostgreSQL/Database/PostgreSQLDatabaseConfig.swift
@@ -21,18 +21,22 @@ public struct PostgreSQLDatabaseConfig {
     
     /// Optional password to use for authentication.
     public let password: String?
+
+    /// Optional ssl connection
+    public let shouldPreferSSL: Bool?
     
     /// Creates a new `PostgreSQLDatabaseConfig`.
-    public init(hostname: String, port: Int = 5432, username: String, database: String? = nil, password: String? = nil) {
+    public init(hostname: String, port: Int = 5432, username: String, database: String? = nil, password: String? = nil, shouldPreferSSL: Bool? = false) {
         self.hostname = hostname
         self.port = port
         self.username = username
         self.database = database
         self.password = password
+        self.shouldPreferSSL = shouldPreferSSL
     }
 
     /// Creates a `PostgreSQLDatabaseConfig` frome a connection string.
-    public init(url: String) throws {
+    public init(url: String, shouldPreferSSL: Bool? = false) throws {
         guard let urL = URL(string: url),
             let hostname = urL.host,
             let port = urL.port,
@@ -55,5 +59,6 @@ public struct PostgreSQLDatabaseConfig {
             self.database = database
         }
         self.password = urL.password
+        self.shouldPreferSSL = shouldPreferSSL
     }
 }

--- a/Sources/PostgreSQL/Message+Parse/PostgreSQLMessageDecoder.swift
+++ b/Sources/PostgreSQL/Message+Parse/PostgreSQLMessageDecoder.swift
@@ -28,7 +28,6 @@ final class PostgreSQLMessageDecoder: ByteToMessageDecoder {
 
         //// peek at messageSize
         guard let messageSize: Int32 = buffer.peekInteger(skipping: MemoryLayout<Byte>.size) else {
-
             // message can still be a SSL Request
             if messageType == .S || messageType == .N {
                 if let data = buffer.readSlice(length: 1) {

--- a/Sources/PostgreSQL/Message+Serialize/PostgreSQLMessageEncoder.swift
+++ b/Sources/PostgreSQL/Message+Serialize/PostgreSQLMessageEncoder.swift
@@ -19,6 +19,9 @@ final class PostgreSQLMessageEncoder: MessageToByteEncoder {
         let encoder = _PostgreSQLMessageEncoder()
         let identifier: Byte?
         switch message {
+        case .sslMessage(let message):
+            identifier = nil
+            try message.encode(to: encoder)
         case .startupMessage(let message):
             identifier = nil
             try message.encode(to: encoder)

--- a/Sources/PostgreSQL/Message/PostgreSQLMessage.swift
+++ b/Sources/PostgreSQL/Message/PostgreSQLMessage.swift
@@ -2,6 +2,11 @@ import Bits
 
 /// A frontend or backend PostgreSQL message.
 enum PostgreSQLMessage {
+    /// Identifies the message as SSL opening sequence
+    case sslMessage(PostgreSQLSSLMessage)
+    /// Identifies the message as the response from the server to SSL message
+    case sslRequest(PostgreSQLSSLRequest)
+    /// Identifies the message as the initial start up message.
     case startupMessage(PostgreSQLStartupMessage)
     /// Identifies the message as an error.
     case error(PostgreSQLDiagnosticResponse)

--- a/Sources/PostgreSQL/Message/PostgreSQLSSLMessage.swift
+++ b/Sources/PostgreSQL/Message/PostgreSQLSSLMessage.swift
@@ -7,15 +7,13 @@
 
 /// First message sent from the frontend during startup if SSL is enabled.
 struct PostgreSQLSSLMessage: Encodable {
-
     /// The SSL request code. The value is chosen to contain 1234 in the most significant 16 bits,
     /// and 5679 in the least significant 16 bits.
-    var sslRequestCode: Int32 = 80877103
+    let sslRequestCode: Int32 = 80877103
 
     /// See Encodable.encode
     func encode(to encoder: Encoder) throws {
         var single = encoder.singleValueContainer()
         try single.encode(sslRequestCode)
     }
-
 }

--- a/Sources/PostgreSQL/Message/PostgreSQLSSLMessage.swift
+++ b/Sources/PostgreSQL/Message/PostgreSQLSSLMessage.swift
@@ -1,0 +1,21 @@
+//
+//  PostgreSQLSSLRequest.swift
+//  Async
+//
+//  Created by franz busch on 15.04.18.
+//
+
+/// First message sent from the frontend during startup if SSL is enabled.
+struct PostgreSQLSSLMessage: Encodable {
+
+    /// The SSL request code. The value is chosen to contain 1234 in the most significant 16 bits,
+    /// and 5679 in the least significant 16 bits.
+    var sslRequestCode: Int32 = 80877103
+
+    /// See Encodable.encode
+    func encode(to encoder: Encoder) throws {
+        var single = encoder.singleValueContainer()
+        try single.encode(sslRequestCode)
+    }
+
+}

--- a/Sources/PostgreSQL/Message/PostgreSQLSSLMessage.swift
+++ b/Sources/PostgreSQL/Message/PostgreSQLSSLMessage.swift
@@ -1,10 +1,3 @@
-//
-//  PostgreSQLSSLRequest.swift
-//  Async
-//
-//  Created by franz busch on 15.04.18.
-//
-
 /// First message sent from the frontend during startup if SSL is enabled.
 struct PostgreSQLSSLMessage: Encodable {
     /// The SSL request code. The value is chosen to contain 1234 in the most significant 16 bits,

--- a/Sources/PostgreSQL/Message/PostgreSQLSSLRequest.swift
+++ b/Sources/PostgreSQL/Message/PostgreSQLSSLRequest.swift
@@ -1,10 +1,3 @@
-//
-//  PostgreSQLSSLRequest.swift
-//  Async
-//
-//  Created by franz busch on 15.04.18.
-//
-
 import Foundation
 
 /// SSL request returned by the server.

--- a/Sources/PostgreSQL/Message/PostgreSQLSSLRequest.swift
+++ b/Sources/PostgreSQL/Message/PostgreSQLSSLRequest.swift
@@ -1,0 +1,16 @@
+//
+//  PostgreSQLSSLRequest.swift
+//  Async
+//
+//  Created by franz busch on 15.04.18.
+//
+
+import Foundation
+
+/// SSL request returned by the server.
+enum PostgreSQLSSLRequest: UInt8, Decodable {
+
+    case S = 83
+    case N = 78
+
+}

--- a/Sources/PostgreSQL/Message/PostgreSQLSSLRequest.swift
+++ b/Sources/PostgreSQL/Message/PostgreSQLSSLRequest.swift
@@ -9,8 +9,6 @@ import Foundation
 
 /// SSL request returned by the server.
 enum PostgreSQLSSLRequest: UInt8, Decodable {
-
     case S = 83
     case N = 78
-
 }

--- a/Tests/PostgreSQLTests/PostgreSQLConnectionTests.swift
+++ b/Tests/PostgreSQLTests/PostgreSQLConnectionTests.swift
@@ -378,8 +378,8 @@ extension PostgreSQLConnection {
         let client = try PostgreSQLConnection.connect(hostname: hostname, on: group) { error in
             XCTFail("\(error)")
         }.wait()
-        _ = try client.establishSSLConnection().wait()
-        _ = try client.authenticate(username: "fb", database: "myteam", password: nil).wait()
+        _ = try client.establishSSLConnection()
+        _ = try client.authenticate(username: "vapor_username", database: "vapor_database", password: nil).wait()
         return client
     }
 }

--- a/Tests/PostgreSQLTests/PostgreSQLConnectionTests.swift
+++ b/Tests/PostgreSQLTests/PostgreSQLConnectionTests.swift
@@ -378,7 +378,7 @@ extension PostgreSQLConnection {
         let client = try PostgreSQLConnection.connect(hostname: hostname, on: group) { error in
             XCTFail("\(error)")
         }.wait()
-        _ = try client.establishSSLConnection()
+        _ = client.establishSSLConnection()
         _ = try client.authenticate(username: "vapor_username", database: "vapor_database", password: nil).wait()
         return client
     }

--- a/Tests/PostgreSQLTests/PostgreSQLConnectionTests.swift
+++ b/Tests/PostgreSQLTests/PostgreSQLConnectionTests.swift
@@ -378,7 +378,8 @@ extension PostgreSQLConnection {
         let client = try PostgreSQLConnection.connect(hostname: hostname, on: group) { error in
             XCTFail("\(error)")
         }.wait()
-        _ = try client.authenticate(username: "vapor_username", database: "vapor_database", password: nil).wait()
+        _ = try client.establishSSLConnection().wait()
+        _ = try client.authenticate(username: "fb", database: "myteam", password: nil).wait()
         return client
     }
 }


### PR DESCRIPTION
This adds support for SSL connections, which are required by providers like Heroku PostgreSQL. I implemented the minimal requirement to enable SSL connections, there is still some cleanup work to do, but I am opening this PR now to get early feedback, especially regarding the usage of flatMap and the changes to the PostgreSQLDecoder. Please let me know what is missing or I have to change to get it merged :)

Definition of the SSL sequence:
https://www.postgresql.org/docs/9.3/static/protocol-flow.html#AEN99924

The format for the message can be found here under SSLRequest:
https://www.postgresql.org/docs/9.1/static/protocol-message-formats.html