### PR TITLE
Add JSONB version to PostgreSQLJSONCustomConvertible

### DIFF
--- a/Sources/PostgreSQL/Data/PostgreSQLJSONCustomConvertible.swift
+++ b/Sources/PostgreSQL/Data/PostgreSQLJSONCustomConvertible.swift
@@ -42,10 +42,15 @@ extension PostgreSQLJSONCustomConvertible {
         guard let encodable = self as? Encodable else {
             fatalError("`\(Self.self)` is not `Encodable`.")
         }
-        return try PostgreSQLData(
+        
+        // JSONB requires version number in a first byte
+        let jsonBVersion: [UInt8] = [0x01]
+        let jsonData = try JSONEncoder().encode(EncoderWrapper(encodable))
+        
+        return PostgreSQLData(
             type: .jsonb,
-            format: .text,
-            data: JSONEncoder().encode(EncoderWrapper(encodable))
+            format: .binary,
+            data: jsonBVersion + jsonData
         )
     }
 }


### PR DESCRIPTION
### Information
Fix bug when user tries to save JSONB (most time it shows when trying to save an array) and receive an error: `unsupported jsonb version number 123`. PostgreSQL requires JSONB version number in a first byte.

https://doxygen.postgresql.org/jsonb_8c_source.html#l00104:
>  **jsonb type recv function**
> The type is sent as text in binary mode, so this is almost the same as the input function, but it's prefixed with a version number so we can change the binary format sent in future if necessary. For now, only version 1 is supported.

### Tests
Current code (before PR) is not working, you can see the error in updated test [at CircleCI](https://circleci.com/gh/vapor/fluent-postgresql/191?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link).
Updated test is located in PR https://github.com/vapor/fluent-postgresql/pull/58.

### Fixes
That commit fixes next issues:
- Fix vapor/fluent-postgresql#38
- Fix vapor/fluent-postgresql#48