### PR TITLE
fix nested unkeyed encoding data

### DIFF
--- a/Sources/PostgreSQL/Codable/PostgreSQLValueEncoder.swift
+++ b/Sources/PostgreSQL/Codable/PostgreSQLValueEncoder.swift
@@ -141,11 +141,13 @@ public struct PostgreSQLDataEncoder {
         }
         
         mutating func encode<T>(_ value: T) throws where T : Encodable {
+            let data: PostgreSQLData
             if let convertible = value as? PostgreSQLDataConvertible {
-                try encoder.array.append(convertible.convertToPostgreSQLData())
+                data = try convertible.convertToPostgreSQLData()
             } else {
-                try value.encode(to: encoder)
+                data = try PostgreSQLDataEncoder().encode(value)
             }
+            encoder.array.append(data)
         }
         
         mutating func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type) -> KeyedEncodingContainer<NestedKey> where NestedKey : CodingKey {

--- a/Sources/PostgreSQL/SQL/PostgreSQLUpsert.swift
+++ b/Sources/PostgreSQL/SQL/PostgreSQLUpsert.swift
@@ -6,12 +6,8 @@ public struct PostgreSQLUpsert: SQLSerializable {
     public typealias Expression = PostgreSQLExpression
     
     /// See `SQLUpsert`.
-    public static func upsert(_ columns: [PostgreSQLColumnIdentifier]?, _ values: [(Identifier, Expression)]) -> PostgreSQLUpsert {
-        if let columns = columns, !columns.isEmpty {
-            return self.init(columns: columns, values: values)
-        } else {
-            return self.init(columns: [.column(nil, .identifier("id"))], values: values)
-        }
+    public static func upsert(_ columns: [PostgreSQLColumnIdentifier], _ values: [(Identifier, Expression)]) -> PostgreSQLUpsert {
+        return self.init(columns: columns, values: values)
     }
     
     /// See `SQLUpsert`.
@@ -24,7 +20,7 @@ public struct PostgreSQLUpsert: SQLSerializable {
     public func serialize(_ binds: inout [Encodable]) -> String {
         var sql: [String] = []
         sql.append("ON CONFLICT")
-        sql.append("(" + columns.serialize(&binds) + ")")
+        sql.append("(" + columns.map { $0.identifier }.serialize(&binds) + ")")
         sql.append("DO UPDATE SET")
         sql.append(values.map { $0.0.serialize(&binds) + " = " + $0.1.serialize(&binds) }.joined(separator: ", "))
         return sql.joined(separator: " ")

--- a/Tests/PostgreSQLTests/PostgreSQLConnectionTests.swift
+++ b/Tests/PostgreSQLTests/PostgreSQLConnectionTests.swift
@@ -540,21 +540,6 @@ class PostgreSQLConnectionTests: XCTestCase {
             print(c)
         }
     }
-    
-    func testUpsert() throws {
-        let values: [(PostgreSQLUpsert.Identifier, PostgreSQLUpsert.Expression)] = []
-        
-        var upsert: PostgreSQLUpsert
-        
-        upsert = PostgreSQLUpsert.upsert(nil, values)
-        XCTAssertEqual(upsert.columns, [PostgreSQLColumnIdentifier.column(nil, .identifier("id"))])
-        
-        upsert = PostgreSQLUpsert.upsert([], values)
-        XCTAssertEqual(upsert.columns, [PostgreSQLColumnIdentifier.column(nil, .identifier("id"))])
-        
-        upsert = PostgreSQLUpsert.upsert([.column(nil, .identifier("field"))], values)
-        XCTAssertEqual(upsert.columns, [PostgreSQLColumnIdentifier.column(nil, .identifier("field"))])
-    }
 
     static var allTests = [
         ("testBenchmark", testBenchmark),
@@ -575,7 +560,6 @@ class PostgreSQLConnectionTests: XCTestCase {
         ("testOrderBy", testOrderBy),
         ("testInvalidDate", testInvalidDate),
         ("testEmptyArray", testEmptyArray),
-        ("testUpsert", testUpsert),
     ]
 }
 


### PR DESCRIPTION
The current algorithm has a logical error that causes unkeyed data to be encoded as single values. This caused issues serializing arrays of enums in FluentPostgreSQL.