### PR TITLE
Fix regexp operator

### DIFF
--- a/Sources/PostgreSQL/SQL/PostgreSQLBinaryOperator.swift
+++ b/Sources/PostgreSQL/SQL/PostgreSQLBinaryOperator.swift
@@ -156,7 +156,7 @@ public enum PostgreSQLBinaryOperator: SQLBinaryOperator, Equatable {
         case ._like: return "LIKE"
         case ._glob: return "GLOB"
         case ._match: return "MATCH"
-        case ._regexp: return "REGEXP"
+        case ._regexp: return "~"
         case ._notLike: return "NOT LIKE"
         case ._notGlob: return "NOT GLOB"
         case ._notMatch: return "NOT MATCH"


### PR DESCRIPTION
This fixes the RegExp operator. PostgreSQL uses `~` and not `REGEXP`.