### PR TITLE
Fix work convertFromPostgreSQLData for Numeric type with zero value

### DIFF
--- a/Sources/PostgreSQL/Data/PostgreSQLData+String.swift
+++ b/Sources/PostgreSQL/Data/PostgreSQLData+String.swift
@@ -26,6 +26,10 @@ extension String: PostgreSQLDataConvertible {
                 /// grab the numeric metadata from the beginning of the array
                 let metadata = value.extract(PostgreSQLNumericMetadata.self)
                 
+                guard metadata.ndigits.bigEndian > 0 else {
+                    return "0"
+                }
+                
                 var integer = ""
                 var fractional = ""
                 for offset in 0..<metadata.ndigits.bigEndian {


### PR DESCRIPTION
**TL;DR**
In cases we have table's fields a `numeric` type and value have zero, we get error 
```console
<unknown>:0: error: -[AppTests.TestTest testSum] : failed: caught error: ⚠️ [PostgreSQLError.decode: Could not decode Int: 0x0000000000000000 (NUMERIC).]
``` 
linked issue https://github.com/vapor/fluent/issues/570

**Explain**  
1. Model
```swift
final class TestTable: PostgreSQLModel {
  
  var id: Int?
  var name: String
  var score: Int
  
  init(
    id: Int? = nil,
    name: String,
    score: Int = 0
    ) throws {
    
    self.id = id
    self.name = name
    self.score = score
  }
  
}

extension TestTable: Migration {
  public static func prepare(on connection: PostgreSQLConnection) -> Future<Void> {
    return PostgreSQLDatabase.create(self, on: connection) { builder in
      builder.field(for: \.id, isIdentifier: true)
      builder.field(for: \.name)
      builder.field(for: \.score, type: PostgreSQLDataType.numeric)
    }
  }
}
``` 
2. Seeding and test 

```swift 
func testNumereric() throws {
    
    let uri = "/api/v1.0/test/get"
    
    _ = try TestTable(name: "test2", score: 2).save(on: conn).wait()
    _ = try TestTable(name: "test3", score: 0).save(on: conn).wait()
    
    let response = try app.sendRequest(to: uri, method: .GET)
    XCTAssertEqual(response.http.status, .ok)
  }
```
3. For record with name "test3 " we got error:
```console
<unknown>:0: error: -[AppTests.TestTest testSum] : failed: caught error: ⚠️ [PostgreSQLError.decode: Could not decode Int: 0x0000000000000000 (NUMERIC).]
```
**Root cause** 
For zero value numeric the `metadata.ndigits.bigEndian` always equal zero, so cycle ` for offset in 0..<metadata.ndigits.bigEndian` never run  and  as result we return empty string and get nil when trying cast String to Int.
`PostgreSQLData+String.swift`:
```swift 
extension String: PostgreSQLDataConvertible {
    /// See `PostgreSQLDataConvertible`.
  public static func convertFromPostgreSQLData(_ data: PostgreSQLData) throws -> String {
        ...
                /// grab the numeric metadata from the beginning of the array
                let metadata = value.extract(PostgreSQLNumericMetadata.self)
                var integer = ""
                var fractional = ""
                for offset in 0..<metadata.ndigits.bigEndian {
                 ...    
```
*Solution*
I offer to get `"0"` always then  `metadata.ndigits.bigEndian ` equal zero. 
An alternative is to deep down to `value.extract (PostgreSQLNumericMetadata.self)` and to search result there.


