### PR TITLE
add failing test case for 0 numeric value

### DIFF
--- a/Sources/PostgreSQL/Data/PostgreSQLData+String.swift
+++ b/Sources/PostgreSQL/Data/PostgreSQLData+String.swift
@@ -26,6 +26,10 @@ extension String: PostgreSQLDataConvertible {
                 /// grab the numeric metadata from the beginning of the array
                 let metadata = value.extract(PostgreSQLNumericMetadata.self)
                 
+                guard metadata.ndigits.bigEndian > 0 else {
+                    return "0"
+                }
+                
                 var integer = ""
                 var fractional = ""
                 for offset in 0..<metadata.ndigits.bigEndian {


### PR DESCRIPTION
Adds a failing test case for the issue fixed in https://github.com/vapor/postgresql/pull/109. 