### PR TITLE
Fix a retain cycle in PostgreSQLConnection

### DIFF
--- a/Sources/PostgreSQL/Connection/PostgreSQLConnection.swift
+++ b/Sources/PostgreSQL/Connection/PostgreSQLConnection.swift
@@ -39,9 +39,9 @@ public final class PostgreSQLConnection: DatabaseConnection, BasicWorker, Databa
         self.isClosed = false
         self.extend = [:]
         self.pipeline = channel.eventLoop.newSucceededFuture(result: ())
-        channel.closeFuture.always {
-            self.isClosed = true
-            if let current = self.currentSend {
+        channel.closeFuture.always { [weak self] in
+            self?.isClosed = true
+            if let current = self?.currentSend {
                 current.fail(error: closeError)
             }
         }

--- a/Tests/PostgreSQLTests/PostgreSQLConnectionTests.swift
+++ b/Tests/PostgreSQLTests/PostgreSQLConnectionTests.swift
@@ -606,6 +606,20 @@ class PostgreSQLConnectionTests: XCTestCase {
             }
         }
     }
+    
+    func testClosureRetainCycle() throws {
+        weak var connection: PostgreSQLConnection?
+        let request: EventLoopFuture<Void>
+        do {
+            let conn = try PostgreSQLConnection.makeTest()
+            request = conn.simpleQuery("SELECT true")
+            connection = conn
+        }
+        XCTAssertNotNil(connection)
+        try request.wait()
+        try request.eventLoop.future().wait()
+        XCTAssertNil(connection)
+    }
 
     static var allTests = [
         ("testBenchmark", testBenchmark),
@@ -628,6 +642,7 @@ class PostgreSQLConnectionTests: XCTestCase {
         ("testEmptyArray", testEmptyArray),
         ("testZeroNumeric", testZeroNumeric),
         ("testNumericDecode", testNumericDecode),
+        ("testClosureRetainCycle", testClosureRetainCycle),
     ]
 }
 


### PR DESCRIPTION
By adding a handler that retains self on the channel's close future, the connection gets retained until the channel is closed. We break the retain cycle by using a weak reference to self. The completion handler in `send(:onResponse:)` is enough to ensure that the connection stays alive while a message is sent to the server.