### PR TITLE
Fix conversion between Date and timestamp/timestamptz types

### DIFF
--- a/Sources/PostgreSQL/Data/PostgreSQLData+Date.swift
+++ b/Sources/PostgreSQL/Data/PostgreSQLData+Date.swift
@@ -11,7 +11,12 @@ extension Date: PostgreSQLDataConvertible {
             }
         case .binary(let value):
             switch data.type {
-            case .timestamp, .timestamptz:
+            case .timestamp:
+                let microseconds = value.as(Int64.self, default: 0).bigEndian
+                var seconds = Double(microseconds) / Double(_microsecondsPerSecond)
+                seconds -= Double(TimeZone.current.secondsFromGMT())
+                return Date(timeInterval: seconds, since: _psqlDateStart)
+            case .timestamptz:
                 let microseconds = value.as(Int64.self, default: 0).bigEndian
                 let seconds = Double(microseconds) / Double(_microsecondsPerSecond)
                 return Date(timeInterval: seconds, since: _psqlDateStart)
@@ -28,7 +33,7 @@ extension Date: PostgreSQLDataConvertible {
 
     /// See `PostgreSQLDataConvertible`.
     public func convertToPostgreSQLData() throws -> PostgreSQLData {
-        return PostgreSQLData(.timestamp, binary: Data.of(Int64(self.timeIntervalSince(_psqlDateStart) * Double(_microsecondsPerSecond)).bigEndian))
+        return PostgreSQLData(.timestamptz, binary: Data.of(Int64(self.timeIntervalSince(_psqlDateStart) * Double(_microsecondsPerSecond)).bigEndian))
     }
 }
 


### PR DESCRIPTION
It seems `timestamp` values are adjusted for the local time zone.
When converting to a `Date`, we need to subtract the local offset to get the correct value.
When converting from a `Date`, it is better to use the `timestamptz` type, which works with both kinds of fields and does not have this problem.