### PR TITLE
Add missing array operators

### DIFF
--- a/Sources/PostgreSQL/SQL/PostgreSQLBinaryOperator.swift
+++ b/Sources/PostgreSQL/SQL/PostgreSQLBinaryOperator.swift
@@ -23,7 +23,7 @@ public struct PostgreSQLBinaryOperator: SQLBinaryOperator, Equatable, Expressibl
 
     /// See `SQLBinaryOperator`.
     public static let equal: PostgreSQLBinaryOperator = "="
-
+    
     /// See `SQLBinaryOperator`.
     public static let greaterThan: PostgreSQLBinaryOperator = ">"
 
@@ -65,7 +65,16 @@ public struct PostgreSQLBinaryOperator: SQLBinaryOperator, Equatable, Expressibl
 
     /// See `SQLBinaryOperator`.
     public static let isNot: PostgreSQLBinaryOperator = "IS NOT"
+    
+    /// See `SQLBinaryOperator`.
+    public static let contains: PostgreSQLBinaryOperator = "@>"
 
+    /// See `SQLBinaryOperator`.
+    public static let containsBy: PostgreSQLBinaryOperator = "<@"
+
+    /// See `SQLBinaryOperator`.
+    public static let overlap: PostgreSQLBinaryOperator = "&&"
+    
     /// See `SQLBinaryOperator`.
     public static let like: PostgreSQLBinaryOperator = "LIKE"
 

--- a/Sources/PostgreSQL/SQL/PostgreSQLBinaryOperator.swift
+++ b/Sources/PostgreSQL/SQL/PostgreSQLBinaryOperator.swift
@@ -70,7 +70,7 @@ public struct PostgreSQLBinaryOperator: SQLBinaryOperator, Equatable, Expressibl
     public static let contains: PostgreSQLBinaryOperator = "@>"
 
     /// See `SQLBinaryOperator`.
-    public static let containsBy: PostgreSQLBinaryOperator = "<@"
+    public static let isContainedBy: PostgreSQLBinaryOperator = "<@"
 
     /// See `SQLBinaryOperator`.
     public static let overlap: PostgreSQLBinaryOperator = "&&"


### PR DESCRIPTION
Some operators to especially compare arrays are missing in the current PostgreSQLBinaryOperator struct.

https://www.postgresql.org/docs/current/functions-array.html