### PR TITLE
Significantly improve performance of row decoding.

### DIFF
--- a/Sources/PostgreSQL/Codable/PostgreSQLRowDecoder.swift
+++ b/Sources/PostgreSQL/Codable/PostgreSQLRowDecoder.swift
@@ -67,7 +67,7 @@ struct PostgreSQLRowDecoder {
         private func data(for key: Key) -> PostgreSQLData? {
             let columnName = key.stringValue
             var column = PostgreSQLColumn(tableOID: self.tableOID, name: columnName)
-            // First, check for an exact (0, columnName) match.
+            // First, check for an exact (tableOID, columnName) match.
             var data = row[column]
             if data == nil {
                 if self.tableOID != 0 {

--- a/Sources/PostgreSQL/Codable/PostgreSQLRowDecoder.swift
+++ b/Sources/PostgreSQL/Codable/PostgreSQLRowDecoder.swift
@@ -106,6 +106,16 @@ struct PostgreSQLRowDecoder {
             return try PostgreSQLDataDecoder().decode(T.self, from: data)
         }
         
+        // This specialization avoids two dictionary lookups (caused by calls to `contains` and `decodeNil`) present in
+        // the default implementation of `decodeIfPresent`.
+        func decodeIfPresent<T>(_ type: T.Type, forKey key: Key) throws -> T? where T : Decodable {
+            guard let data = data(for: key) else { return nil }
+            switch data.storage {
+            case .null: return nil
+            default: return try PostgreSQLDataDecoder().decode(T.self, from: data)
+            }
+        }
+        
         func nestedContainer<NestedKey>(keyedBy type: NestedKey.Type, forKey key: Key) throws -> KeyedDecodingContainer<NestedKey> where NestedKey : CodingKey {
             fatalError()
         }

--- a/Sources/PostgreSQL/Column/PostgreSQLColumn.swift
+++ b/Sources/PostgreSQL/Column/PostgreSQLColumn.swift
@@ -25,8 +25,8 @@ extension PostgreSQLColumn: CustomStringConvertible {
 
 extension Dictionary where Key == PostgreSQLColumn {
     /// Accesses the _first_ value from this dictionary with a matching field name.
-	///
-	/// - Note: This performs a linear search over the dictionary and thus is fairly slow.
+    ///
+    /// - Note: This performs a linear search over the dictionary and thus is fairly slow.
     public func firstValue(tableOID: UInt32 = 0, name: String) -> Value? {
         for (column, data) in self {
             if (tableOID == 0 || column.tableOID == 0 || column.tableOID == tableOID) && column.name == name {

--- a/Sources/PostgreSQL/Column/PostgreSQLColumn.swift
+++ b/Sources/PostgreSQL/Column/PostgreSQLColumn.swift
@@ -25,6 +25,8 @@ extension PostgreSQLColumn: CustomStringConvertible {
 
 extension Dictionary where Key == PostgreSQLColumn {
     /// Accesses the _first_ value from this dictionary with a matching field name.
+	///
+	/// - Note: This performs a linear search over the dictionary and thus is fairly slow.
     public func firstValue(tableOID: UInt32 = 0, name: String) -> Value? {
         for (column, data) in self {
             if (tableOID == 0 || column.tableOID == 0 || column.tableOID == tableOID) && column.name == name {

--- a/Sources/PostgreSQL/Connection/PostgreSQLConnection+TableNameCache.swift
+++ b/Sources/PostgreSQL/Connection/PostgreSQLConnection+TableNameCache.swift
@@ -43,7 +43,7 @@ extension PostgreSQLConnection {
             self.tableOIDs = tableOIDs
         }
     }
-    
+
     /// Fetches a struct that can convert table OIDs to table names.
     ///
     ///     SELECT oid, relname FROM pg_class

--- a/Sources/PostgreSQL/Connection/PostgreSQLConnection+TableNameCache.swift
+++ b/Sources/PostgreSQL/Connection/PostgreSQLConnection+TableNameCache.swift
@@ -1,8 +1,17 @@
+private struct PGClass: PostgreSQLTable {
+    static let sqlTableIdentifierString = "pg_class"
+    var oid: UInt32
+    var relname: String
+}
+
 extension PostgreSQLConnection {
     /// Caches table OID to string name associations.
     public struct TableNameCache {
         /// Stores table names. [OID: Name]
         private let tableNames: [UInt32: String]
+        /// Stores table OIDs. [Name: OID]
+        /// Used to accelerate the Name -> OID lookup.
+        private let tableOIDs: [String: UInt32]
         
         /// Fetches the table name for a given table OID. Returns `nil` if no table with that OID is known.
         ///
@@ -19,20 +28,22 @@ extension PostgreSQLConnection {
         ///     - name: Table name.
         /// - returns: Table OID.
         public func tableOID(name: String) -> UInt32? {
-            for (key, val) in tableNames {
-                if val == name {
-                    return key
-                }
-            }
-            return nil
+            return tableOIDs[name]
         }
         
         /// Creates a new cache.
-        init(_ tableNames: [UInt32: String]) {
+        fileprivate init(_ tableClasses: [PGClass]) {
+            var tableNames: [UInt32: String] = [:]
+            var tableOIDs: [String: UInt32] = [:]
+            for tableClass in tableClasses {
+                tableNames[tableClass.oid] = tableClass.relname
+                tableOIDs[tableClass.relname] = tableClass.oid
+            }
             self.tableNames = tableNames
+            self.tableOIDs = tableOIDs
         }
     }
-
+    
     /// Fetches a struct that can convert table OIDs to table names.
     ///
     ///     SELECT oid, relname FROM pg_class
@@ -42,18 +53,9 @@ extension PostgreSQLConnection {
         if let existing = tableNameCache, !refresh {
             return future(existing)
         } else {
-            struct PGClass: PostgreSQLTable {
-                static let sqlTableIdentifierString = "pg_class"
-                var oid: UInt32
-                var relname: String
-            }
             return select().column("oid").column("relname").from(PGClass.self).all().map { rows in
-                var cache: [UInt32: String] = [:]
                 let rows = try rows.map { try self.decode(PGClass.self, from: $0, table: nil) }
-                for row in rows {
-                    cache[row.oid] = row.relname
-                }
-                let new = TableNameCache(cache)
+                let new = TableNameCache(rows)
                 self.tableNameCache = new
                 return new
             }


### PR DESCRIPTION
Motivation:

1. `PostgreSQLRowDecoder`: `_KeyedDecodingContainer.decode` is called once for each key on the decoded object. With the current implementation, this performs a linear search on the `row` dictionary, which results in a total runtime (per object) of O(keys * columns), i.e. quadratic runtime ~O(keys^2). We replace the current linear search with one or two dictionary lookups if `tableOID != 0`, resulting in linear runtime (per object) in the number of keys (provided dictionary lookups can be assumed to take roughly constant time).
2. `PostgreSQLConnection.TableNameCache`: Most lookups are `tableName -> OID`. We accelerate that lookup by preparing a dictionary for that kind of lookup ahead of time, again replacing linear search.

Effect:

The time required for decoding ~5k objects with 9 fields each drops from ~0.4s on a Core i7-6700k (Release build) to ~0.2s, effectively doubling throughput. Optimization 1 contributes ~130 ms, Optimization 2 contributes ~70ms.